### PR TITLE
Ensure ConfigMap endpoints show correct messages

### DIFF
--- a/k8s/configmap.yml
+++ b/k8s/configmap.yml
@@ -10,6 +10,7 @@ data:
   
   # Application-specific configuration that will hot reload
   app.message: "Hello from ConfigMap - Hot Reload Ready!"
+  app.cm1.message: "Hello from ConfigMap 1 - Hot Reload Ready!"
   app.environment: "Kubernetes"
   app.refreshCount: "1"
   

--- a/src/main/java/com/example/MessageController.java
+++ b/src/main/java/com/example/MessageController.java
@@ -17,7 +17,7 @@ public class MessageController {
     private ConfigurationChangeListener configListener;
 
     // Properties from ConfigMap 1 (hot-reload-cm)
-    @Value("${app.message:No message from ConfigMap 1}")
+    @Value("${app.cm1.message:No message from ConfigMap 1}")
     private String configMap1Message;
     
     @Value("${app.environment:No environment from ConfigMap 1}")
@@ -120,7 +120,7 @@ public class MessageController {
         sb.append("SPRING_PROFILES_ACTIVE: ").append(System.getenv("SPRING_PROFILES_ACTIVE")).append("\n\n");
         
         sb.append("ConfigMap 1 Properties:\n");
-        sb.append("app.message: ").append(configMap1Message).append("\n");
+        sb.append("app.cm1.message: ").append(configMap1Message).append("\n");
         sb.append("app.environment: ").append(configMap1Environment).append("\n");
         sb.append("app.refreshCount: ").append(configMap1RefreshCount).append("\n\n");
         
@@ -149,7 +149,7 @@ public class MessageController {
     
     @GetMapping("/test-cm2")
     public String testConfigMap2() {
-        return "ConfigMap 2 Message: " + configMap2Message + " | Database URL: " + configMap2DatabaseUrl + " | Cache TTL: " + configMap2CacheTtl;
+        return "ConfigMap 2 Message: " + configMap2Message;
     }
 
     @GetMapping("/manual-refresh")
@@ -170,7 +170,7 @@ public class MessageController {
         
         // Test if Spring properties are being loaded
         sb.append("Spring Properties:\n");
-        sb.append("app.message: ").append(configMap1Message).append("\n");
+        sb.append("app.cm1.message: ").append(configMap1Message).append("\n");
         sb.append("app.database.url: ").append(configMap2DatabaseUrl).append("\n");
         
         return sb.toString();


### PR DESCRIPTION
## Summary
- Use `app.cm1.message` so ConfigMap 1 and ConfigMap 2 don't conflict
- Simplify `/test-cm2` endpoint to return only its message
- Document new `app.cm1.message` key in sample ConfigMap

## Testing
- ⚠️ `mvn -q test` *(failed: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e21558448323b0597a94d9a17499